### PR TITLE
Fix links to sign in and sign out

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kobbleio/next",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kobbleio/next",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "license": "ISC",
       "dependencies": {
         "path-to-regexp": "^6.2.2"

--- a/src/client/components/LoginButton.tsx
+++ b/src/client/components/LoginButton.tsx
@@ -8,7 +8,6 @@ import { routes } from '../../constants';
 import { useAssertWrappedByKobbleProvider } from '../context/hooks';
 import { assertSingleChild } from './utils/assertSingleChild';
 import { executeFunctionSafely } from './utils/executeFunctionSafely';
-import env from '../env';
 
 export const LoginButton: React.FC<PropsWithChildren> = ({ children, ...rest }) => {
 	useAssertWrappedByKobbleProvider(LogoutButton.name);
@@ -21,7 +20,7 @@ export const LoginButton: React.FC<PropsWithChildren> = ({ children, ...rest }) 
 	const ourClickHandler = async () => {
 		await executeFunctionSafely((child as any).props.onClick);
 
-		router.push(new URL(routes.login, env.domain).toString());
+		router.push(routes.login);
 	};
 
 	const childProps = { ...rest, onClick: ourClickHandler };

--- a/src/client/components/LoginButton.tsx
+++ b/src/client/components/LoginButton.tsx
@@ -8,6 +8,7 @@ import { routes } from '../../constants';
 import { useAssertWrappedByKobbleProvider } from '../context/hooks';
 import { assertSingleChild } from './utils/assertSingleChild';
 import { executeFunctionSafely } from './utils/executeFunctionSafely';
+import env from '../env';
 
 export const LoginButton: React.FC<PropsWithChildren> = ({ children, ...rest }) => {
 	useAssertWrappedByKobbleProvider(LogoutButton.name);
@@ -20,7 +21,7 @@ export const LoginButton: React.FC<PropsWithChildren> = ({ children, ...rest }) 
 	const ourClickHandler = async () => {
 		await executeFunctionSafely((child as any).props.onClick);
 
-		router.push(routes.login);
+		router.push(new URL(routes.login, env.domain).toString());
 	};
 
 	const childProps = { ...rest, onClick: ourClickHandler };

--- a/src/client/context/auth/provider.tsx
+++ b/src/client/context/auth/provider.tsx
@@ -5,7 +5,6 @@ import { useRouter, usePathname } from "next/navigation";
 import { routes } from "../../../constants";
 import { createContext } from 'react'
 import { User } from '../../../types';
-import env from '../../env';
 
 export type AuthContextValue = {
 	user: User | null;
@@ -52,12 +51,12 @@ export const AuthProvider: React.FC<PropsWithChildren> = ({ children }) => {
 	}, [])
 
 	const logout = () => {
-		router.replace(new URL(routes.logout, env.domain).toString());
+		router.replace(routes.logout);
 		setUser(null);
 	}
 
 	const login = () => {
-		router.replace(new URL(routes.login, env.domain).toString());
+		router.replace(routes.login);
 	}
 
 	return (

--- a/src/client/context/auth/provider.tsx
+++ b/src/client/context/auth/provider.tsx
@@ -5,6 +5,7 @@ import { useRouter, usePathname } from "next/navigation";
 import { routes } from "../../../constants";
 import { createContext } from 'react'
 import { User } from '../../../types';
+import env from '../../env';
 
 export type AuthContextValue = {
 	user: User | null;
@@ -51,12 +52,12 @@ export const AuthProvider: React.FC<PropsWithChildren> = ({ children }) => {
 	}, [])
 
 	const logout = () => {
-		router.replace(routes.logout);
+		router.replace(new URL(routes.logout, env.domain).toString());
 		setUser(null);
 	}
 
 	const login = () => {
-		router.replace('/login');
+		router.replace(new URL(routes.login, env.domain).toString());
 	}
 
 	return (


### PR DESCRIPTION
# Error: 

There is a link that not used the constant file
```ts
	const login = () => {
		router.replace('/login');
	}
```

# Solution:

Simply use the constant to don't go on `/login` but `/api/kobble/login`
```ts
	const login = () => {
		router.replace(routes.login);
	}
```