### PR TITLE
Allow NEXT_PUBLIC_KOBBLE_DOMAIN to be an URL or a Domain

### DIFF
--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -12,10 +12,21 @@ const loadConfig = (): Config => {
 		throw new Error('Missing NEXT_PUBLIC_KOBBLE_CLIENT_ID');
 	}
 
-	const portalUrl = process.env.NEXT_PUBLIC_KOBBLE_DOMAIN;
+	let portalUrl = process.env.NEXT_PUBLIC_KOBBLE_DOMAIN;
 
 	if (!portalUrl) {
 		throw new Error('Missing NEXT_PUBLIC_KOBBLE_DOMAIN');
+	}
+
+	try {
+		portalUrl = new URL(portalUrl).href;
+	} catch (error) {
+		try {
+			portalUrl = new URL(`https://${portalUrl}`).href;
+			console.warn('NEXT_PUBLIC_KOBBLE_DOMAIN is used as a domain but should start with https://');
+		} catch (error) {
+			throw new Error('Invalid format NEXT_PUBLIC_KOBBLE_DOMAIN');
+		}
 	}
 
 	const redirectUri = process.env.NEXT_PUBLIC_KOBBLE_REDIRECT_URI;


### PR DESCRIPTION
# Problem
The NEXT_PUBLIC_KOBBLE_DOMAIN name can be confusing between a domain name and a url.

# Answer
A simple solution is to accept both formats.

# Warning
To avoid unnecessary cpu usage, I have specified a warning if the user is using a domain rather than a url, so you might want to remove it if you want to accept both cases definitively. 