### PR TITLE
Delete duplicate export for PortalLink

### DIFF
--- a/src/client/components/index.ts
+++ b/src/client/components/index.ts
@@ -4,7 +4,6 @@ export * from './IsAllowed';
 export * from './PortalLink';
 export * from './IsForbidden';
 export * from './PricingLink';
-export * from './PortalLink';
 export * from './LogoutButton';
 export * from './LoginButton';
 export * from './ProfileLink';


### PR DESCRIPTION
Very quickfix 😀
The index was exporting 2 times the same component.