### PR TITLE
Allow to pass props to Login and Logout button

### DIFF
--- a/src/client/components/LoginButton.tsx
+++ b/src/client/components/LoginButton.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { PropsWithChildren } from 'react';
+import React from 'react';
 import { defaultButtonIfNoChild } from './utils/defaultButtonIfNoChild';
 import { LogoutButton } from './LogoutButton';
 import { useRouter } from 'next/navigation';
@@ -9,7 +9,7 @@ import { useAssertWrappedByKobbleProvider } from '../context/hooks';
 import { assertSingleChild } from './utils/assertSingleChild';
 import { executeFunctionSafely } from './utils/executeFunctionSafely';
 
-export const LoginButton: React.FC<PropsWithChildren> = ({ children, ...rest }) => {
+export const LoginButton: React.FC<React.ButtonHTMLAttributes<HTMLButtonElement>> = ({ children, ...rest }) => {
 	useAssertWrappedByKobbleProvider(LogoutButton.name);
 
 	const router = useRouter();

--- a/src/client/components/LogoutButton.tsx
+++ b/src/client/components/LogoutButton.tsx
@@ -1,12 +1,12 @@
 'use client';
 
-import React, { PropsWithChildren } from 'react';
+import React from 'react';
 import { defaultButtonIfNoChild } from './utils/defaultButtonIfNoChild';
 import { useAssertWrappedByKobbleProvider, useAuth } from '../context/hooks';
 import { assertSingleChild } from './utils/assertSingleChild';
 import { executeFunctionSafely } from './utils/executeFunctionSafely';
 
-export const LogoutButton: React.FC<PropsWithChildren> = ({ children, ...rest }) => {
+export const LogoutButton: React.FC<React.ButtonHTMLAttributes<HTMLButtonElement>> = ({ children, ...rest }) => {
 	useAssertWrappedByKobbleProvider(LogoutButton.name);
 
 	const { logout } = useAuth();


### PR DESCRIPTION
For now we could not pass any props to logout or login button, we need to declare a button as child with props.

This feature is to be able to pass props to the default button if no child or to overwrite them.

Old way:
```tsx
<LogoutButton>
  <button className="font-medium text-blue-600 dark:text-blue-500 hover:underline">Logout</button>
</LogoutButton>
```

New way (but still compatible with old way):
```tsx
<LogoutButton className="font-medium text-blue-600 dark:text-blue-500 hover:underline">
  Logout
</LogoutButton>
```
